### PR TITLE
自分以外のアイテムが見えないようにする。

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Validator;
 use App\Models\Item;
+use Auth;
 
 class ItemController extends Controller
 {
@@ -50,7 +51,9 @@ class ItemController extends Controller
           }
           // create()は最初から用意されている関数
           // 戻り値は挿入されたレコードの情報
-          $result = Item::create($request->all());
+        //   $result = Item::create($request->all());
+        $data = $request->merge(['user_id' => Auth::user()->id])->all();
+        $result = Item::create($data);
           // ルーティング「todo.index」にリクエスト送信（一覧ページに移動）
           return redirect()->route('item.index');
     }

--- a/database/migrations/2022_10_14_120914_add_user_id_to_items_table.php
+++ b/database/migrations/2022_10_14_120914_add_user_id_to_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('id')->nullable()->constrained()->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn(['user_id']);
+        });
+    }
+};

--- a/resources/views/item/index.blade.php
+++ b/resources/views/item/index.blade.php
@@ -17,6 +17,7 @@
             </thead>
             <tbody>
               @foreach ($items as $item)
+              @if ($item->user_id == Auth::user()->id)
               <tr class="hover:bg-grey-lighter">
                 <td class="py-4 px-6 border-b border-grey-light">
                     <!--{{$item->item_name}} が 何を表示するかを決めている部分です。-->
@@ -29,6 +30,7 @@
                   </div>
                 </td>
               </tr>
+              @endif
               @endforeach
             </tbody>
           </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,11 @@ use App\Http\Controllers\ItemController;
 */
 Route::resource('item', ItemController::class);
 
-Route::get('/', function () {
+// Route::group(['middleware' => 'auth'], function () {
+//     Route::resource('item', ItemController::class);
+//   });
+
+  Route::get('/', function () {
     return view('welcome');
 });
 


### PR DESCRIPTION
php artisan make:migration add_user_id_to_items_table
php artisan migrate
のコマンドの実行する必要があります。

やった事
1. usersテーブルとitemsテーブルを連携(user_idについて)を作成。
2. index.blade.php内の、アイテムの表示を担う箇所19~30行目)に @if ($item->user_id == Auth::user()->id) を追記して、itemに登録しているユーザとログインしているuserのidが一致しているアイテムのみを表示するように変更。