### PR TITLE
文字数制限を消しました。

### DIFF
--- a/database/migrations/2022_10_09_073453_create_items_table.php
+++ b/database/migrations/2022_10_09_073453_create_items_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('items', function (Blueprint $table) {
             $table->id();
-            $table->string('item_name');
-            $table->string('item_link');
+            $table->text('item_name');
+            $table->text('item_link');
             $table->integer('item_price');
             // $table->integer('item_time');
             $table->timestamps();


### PR DESCRIPTION
注意事項
データベース(itemテーブルやuserテーブル)を初期化する必要があります。

必要なコマンド
php artisan migrate:fresh
(データベースの設定リセットのために使用しました)
php artisan db:seed
(userテーブルの中にuserを生成するために使用しました。既存のuser情報は帰ってきません。)

解決方法
linkのデータの形式が255文字しか入らない形式になっていたので、text形式に変更しました