### PR TITLE
自動で定期実行される論理削除の機能を実装しました。

### DIFF
--- a/app/Console/Commands/ScheduledDelete.php
+++ b/app/Console/Commands/ScheduledDelete.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Item;
+use Illuminate\Http\Request;
+
+class ScheduledDelete extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:destroy';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete Item';
+
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $deleteItems = Item::where('updated_at', '<=', now()->subMinute())->get();
+        // ($deleteItems);
+        foreach ($deleteItems as $deleteItem){
+            $result = $deleteItem->delete();
+            // dd($deleteItem);
+        }
+        // return redirect()->route('item.index');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('model:prune')->everyTwoMinutes();
+        $schedule->command('command:destroy')->everyMinute();
     }
 
     /**

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -22,9 +22,11 @@ class Item extends Model
     {
         return self::orderBy('updated_at', 'desc')->get();
     }
-    public function prunable()
-    {
-        return static::where('created_at', '<=', now()->subSeconds(10));
-        //10秒前のデータを削除
-    }
+    // public function softdeletes()
+    // {
+    //     // $result = Item::find($id)->delete();
+    //     // return redirect()->route('item.index');
+    //     return static::where('updated_at', '<=', now()->subSeconds(10));
+    //     //10秒前のデータを削除
+    // }
 }

--- a/softdelete
+++ b/softdelete
@@ -1,0 +1,6 @@
+
+   ERROR  Command "model:Item-" is not defined. Did you mean one of these?  
+
+  ⇂ model:prune  
+  ⇂ model:show  
+

--- a/softdeletes
+++ b/softdeletes
@@ -1,0 +1,6 @@
+
+   ERROR  Command "model:Item-" is not defined. Did you mean one of these?  
+
+  ⇂ model:prune  
+  ⇂ model:show  
+


### PR DESCRIPTION
使い方
php artisan schedule:work
で毎分実行されます。

実行の流れ
php artisan schedule:work でapp/console/Kernel.phpのschedule関数が実行されて、command:destroy を実行するタイミングかどうかを確認します。今回は、一分ごとにしています。
command:destroyが実行されるタイミングになると、app/console/Commands/ScheduleDelete.php に飛びます。
これは、コマンドを定義しているphpファイルです。このphpファイルは、
protected $signature = 'command:destroy';
で実行の仕方(command:destroy)を定義し、
public function handle()
で実際の動作を定義しています。
関数の中身は、まず、削除が必要なアイテムの一覧を取得(37行目)して、それをforeachで削除している流れです。